### PR TITLE
switch unauthorized to all services, fix detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Below are each of the 15 filters that are applied to the Eventbridge rules. They
 
 ### 4.1 Unauthorized API calls
     {
-      "source": ["aws.cloudtrail"],
-      "detail-type": ["AWS API Call via CloudTrail"],
-      "errorCode": ["AccessDenied", "*UnauthorizedOperation"]
+    "detail-type": ["AWS API Call via CloudTrail"],
+    "detail": {
+        "errorCode": ["AccessDenied*", "*UnauthorizedOperation"]
     }
+
 
 ### 4.2 Console Login without MFA
     {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,9 +135,10 @@ resource "aws_cloudwatch_event_rule" "CIS-Alert-4-1" {
 
   event_pattern = <<EOF
 {
-  "source": ["aws.cloudtrail"],
   "detail-type": ["AWS API Call via CloudTrail"],
-  "errorCode": ["AccessDenied", "*UnauthorizedOperation"]
+  "detail": {
+    "errorCode": ["AccessDenied", "*UnauthorizedOperation"]
+  }
 }
 EOF
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_event_rule" "CIS-Alert-4-1" {
 {
   "detail-type": ["AWS API Call via CloudTrail"],
   "detail": {
-    "errorCode": ["AccessDenied", "*UnauthorizedOperation"]
+    "errorCode": ["AccessDenied*", "*UnauthorizedOperation"]
   }
 }
 EOF


### PR DESCRIPTION
## What does this PR do?

Fixes detail to search down the event.
Removes source of cloudtrail to encompass all services - only cloudtrail-calls were being detected.




## What image or gif best represents this PR?
![giphy](https://user-images.githubusercontent.com/4472883/134684496-09989693-d7dc-49d4-bc0f-d00e1b473098.gif)


